### PR TITLE
Cross-platform SSM Parameter Store

### DIFF
--- a/aws_ssm_parameter_account_key.tf
+++ b/aws_ssm_parameter_account_key.tf
@@ -1,6 +1,23 @@
-resource "aws_ssm_parameter" "firebase_service_account_key" {
-  count = length(data.google_projects.firebase_projects.projects)
-  name  = "/google_cloud_ci_cd_service_account_generator/firebase_service_account_keys/${data.google_projects.firebase_projects.projects[count.index].project_id}"
-  type  = "SecureString"
-  value = base64decode(google_service_account_key.firebase_service_account_key[count.index].private_key)
+resource "aws_ssm_parameter" "firebase_service_account_key-dev-eu" {
+  provider = aws.dev-eu
+  count    = length(data.google_projects.firebase_projects.projects)
+  name     = "/google_cloud_ci_cd_service_account_generator/firebase_service_account_keys/${data.google_projects.firebase_projects.projects[count.index].project_id}"
+  type     = "SecureString"
+  value    = base64decode(google_service_account_key.firebase_service_account_key[count.index].private_key)
+}
+
+resource "aws_ssm_parameter" "firebase_service_account_key-qa-eu" {
+  provider = aws.qa-eu
+  count    = length(data.google_projects.firebase_projects.projects)
+  name     = "/google_cloud_ci_cd_service_account_generator/firebase_service_account_keys/${data.google_projects.firebase_projects.projects[count.index].project_id}"
+  type     = "SecureString"
+  value    = base64decode(google_service_account_key.firebase_service_account_key[count.index].private_key)
+}
+
+resource "aws_ssm_parameter" "firebase_service_account_key-prod-eu" {
+  provider = aws.prod-eu
+  count    = length(data.google_projects.firebase_projects.projects)
+  name     = "/google_cloud_ci_cd_service_account_generator/firebase_service_account_keys/${data.google_projects.firebase_projects.projects[count.index].project_id}"
+  type     = "SecureString"
+  value    = base64decode(google_service_account_key.firebase_service_account_key[count.index].private_key)
 }

--- a/backend.tf
+++ b/backend.tf
@@ -1,6 +1,8 @@
 terraform {
   backend "s3" {
-    bucket = "bfan-terraform-state-bucket"
-    key    = "google_cloud_ci_cd_service_account_generator.tfstate"
+    region  = "eu-west-1"
+    bucket  = "bfan-terraform-state-bucket"
+    key     = "google_cloud_ci_cd_service_account_generator.tfstate"
+    profile = "prod-eu"
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -1,11 +1,24 @@
-# We will be using environment variables
+# One provider per AWS account
 provider "aws" {
+  profile = "dev-eu"
+  region  = "eu-west-1"
+  alias   = "dev-eu"
+}
+provider "aws" {
+  profile = "qa-eu"
+  region  = "eu-west-1"
+  alias   = "qa-eu"
+}
+provider "aws" {
+  profile = "prod-eu"
+  region  = "eu-west-1"
+  alias   = "prod-eu"
 }
 
 # We will be using the default credentials from
 # `gcloud auth application-default login
 provider "google" {
-    request_reason = "google_cloud_ci_cd_service_account_generator"
+  request_reason = "google_cloud_ci_cd_service_account_generator"
 }
 
 provider "time" {


### PR DESCRIPTION
SSM PS doesn't support cross-account, so I have to deploy the resources across all 3 environments.
Merge this after https://github.com/hashicorp/terraform/issues/32465 is fixed