### PR TITLE
AI Audit: Findings and Recommendations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,6 @@ make plan-dev-eu
 make apply-dev-eu
 ```
 
-<!-- Ask: What does `make dev` do? Set up gcloud auth and AWS profile? -->
-<!-- Ask: Are the generated keys automatically rotated? How often? -->
-
 ## Project Structure
 
 ```
@@ -42,6 +39,8 @@ google_cloud_ci_cd_service_account_generator/
 ├── versions.tf                   # Terraform/provider versions
 ├── Makefile                      # Environment commands
 ├── modules/                      # Terraform modules
+│   ├── google_cloud_ci_cd_service_account_generator/  # CI/CD SA keys → SSM
+│   └── firebase_cloud_messaging_aws_sns/              # FCM SA keys → SNS
 ├── dev-eu/                       # Dev environment config
 ├── qa-eu/                        # QA environment config
 ├── prod-eu/                      # Prod environment config
@@ -52,8 +51,8 @@ google_cloud_ci_cd_service_account_generator/
 ## Dependencies
 
 **Tools:**
-- OpenTofu (specified in `.opentofu-version`)
-- Terragrunt (specified in `.terragrunt-version`)
+- OpenTofu 1.9.0 (specified in `.opentofu-version`)
+- Terragrunt 0.72.0 (specified in `.terragrunt-version`)
 - gcloud CLI
 - AWS CLI
 
@@ -95,22 +94,60 @@ firebase projects:list
 - **IAM-as-Code**: Service accounts and IAM bindings managed via Terraform
 - **Cross-cloud**: Google Cloud service accounts stored in AWS infrastructure
 
+## GCP IAM Roles & Security
+
+### Roles Used
+
+| Role | Module | Purpose | Scope |
+|------|--------|---------|-------|
+| `roles/firebase.admin` | `google_cloud_ci_cd_service_account_generator` | CI/CD Firebase deployments | Per-project |
+| `roles/firebase.growthAdmin` | `firebase_cloud_messaging_aws_sns` | FCM push via AWS SNS | Per-project |
+
+### Least Privilege Considerations
+
+- `roles/firebase.admin` is broad — grants full read/write/delete across all Firebase services. For CI/CD that only deploys Hosting or Functions, prefer scoped roles like `roles/firebasehosting.admin` or `roles/cloudfunctions.developer`.
+- `roles/firebase.growthAdmin` includes FCM but also A/B Testing, Remote Config, and Dynamic Links. A custom role with only `cloudmessaging.messages.create` is more restrictive.
+- Both modules use `google_project_iam_member` (additive). This does NOT remove existing role bindings — it only adds. Out-of-band IAM changes are not detected.
+
+### Service Account Key Lifecycle
+
+1. `data.google_projects` discovers Firebase projects by label (`firebase:enabled`)
+2. One `google_service_account` is created per discovered project
+3. `time_rotating` (1-day period) triggers key recreation on `terraform apply`
+4. `google_service_account_key` generates a new JSON key
+5. Key is base64-decoded and stored as `SecureString` in AWS SSM
+6. Old key is destroyed by Terraform (replaced in state)
+
+**Critical detail:** Step 3 only triggers when `terraform apply` actually runs. If nobody runs apply, keys persist beyond the 1-day rotation window. There is no scheduled automation enforcing rotation.
+
+### Key Security Architecture
+
+```
+GCP Org (744998649083)
+  └── Firebase Project (e.g., bfan-stadefrancais)
+        └── Service Account (bfan-firebase-ci-cd-{env})
+              └── SA Key (JSON, rotated on apply)
+                    └── Stored in AWS SSM (SecureString, default KMS)
+                          └── Read by CI/CD (Bitrise, GitHub Actions)
+```
+
+**Cross-cloud trust boundary:** GCP credentials cross into AWS. Compromise of either cloud's IAM could expose the other's resources. The SSM parameter path is the single choke point.
+
 ## Environment
 
 **Google Cloud:**
 - Org ID: `744998649083`
 - Required Role: `Security Admin` (for IAM bindings)
-- Firebase projects: `bfan-stadefrancais`, `fkcrvenazvezda`, etc.
+- Firebase projects: dynamically discovered via `labels.firebase:enabled`
 
 **AWS:**
-- SSM Parameter Store (encrypted)
+- SSM Parameter Store (encrypted with default `aws/ssm` KMS key)
 - S3 backend for Terraform state: `s3://bfan-terraform-state-bucket-{env}`
+- State locking: NOT enabled (DynamoDB table TODO)
 
 **Environment Variables:**
 - `GOOGLE_APPLICATION_CREDENTIALS` — Path to service account JSON (output)
-
-<!-- Ask: What Firebase projects are managed? Is there a list in the Terraform config? -->
-<!-- Ask: Are there Terragrunt dependencies between dev/qa/prod? -->
+- `AWS_PROFILE` — AWS CLI profile for target environment
 
 ## Deployment
 
@@ -139,11 +176,11 @@ make apply-prod-eu
 **Key Rotation:**
 - Keys rotate automatically on every `terraform apply`
 - CI/CD pipelines must fetch fresh keys on each build
+- No automated schedule exists — rotation depends on manual runs
 
 ## Testing
 
-<!-- Ask: Are there tests for the Terraform modules? -->
-<!-- Ask: How is the infrastructure validated before apply? -->
+No automated tests exist for the Terraform modules.
 
 **Manual Validation:**
 ```bash
@@ -152,16 +189,61 @@ export GOOGLE_APPLICATION_CREDENTIALS=./firebase_service_account_keys/bfan-stade
 firebase projects:list
 ```
 
+**Recommended validation before apply:**
+```bash
+# Always plan first
+make plan-prod-eu
+# Review the plan output for unexpected changes
+# Check service account count matches expected Firebase projects
+# Verify no resources are being destroyed unexpectedly
+```
+
 ## Gotchas
 
-- **Key Rotation on Apply**: Every `terraform apply` recreates ALL keys — not a bug, it's intentional
-- **Security Admin Role**: Terraform fails if Google Cloud user lacks `Security Admin` role
-- **Firebase Token Deprecation**: Old `FIREBASE_TOKEN` env var no longer works; must use service account keys
-- **S3 State Bucket**: Must be created manually before first Terraform run
-- **Cross-account Access**: `fkcrvenazvezda` project requires `dev-google@bfansports.com` account specifically
-- **Terragrunt Version**: `.terragrunt-version` file locks version; update only when necessary
-- **OpenTofu vs Terraform**: Project uses OpenTofu (Terraform fork); ensure correct binary installed
-- **SSM Parameter Paths**: Hardcoded prefix; changing requires CI/CD pipeline updates
-- **Key File Gitignore**: Generated keys in `firebase_service_account_keys/` must stay gitignored
-- **IAM Propagation Delay**: After creating service account, IAM bindings may take 60s to propagate
-- **Firebase CLI Version**: Older Firebase CLI versions don't support service account auth
+- **Key Rotation on Apply**: Every `terraform apply` recreates ALL keys — not a bug, it's intentional rotation. CI/CD pipelines must fetch keys on every build, not cache them.
+- **Security Admin Role**: Terraform fails if Google Cloud user lacks `Security Admin` role on the org.
+- **Firebase Token Deprecation**: Old `FIREBASE_TOKEN` env var no longer works; must use service account keys.
+- **S3 State Bucket**: Must be created manually before first Terraform run.
+- **Cross-account Access**: `fkcrvenazvezda` project requires `dev-google@bfansports.com` account specifically.
+- **Terragrunt Version**: `.terragrunt-version` file locks version; update only when necessary.
+- **OpenTofu vs Terraform**: Project uses OpenTofu (Terraform fork); ensure correct binary installed.
+- **SSM Parameter Paths**: Hardcoded prefix; changing requires CI/CD pipeline updates across all repos that consume these keys.
+- **Key File Gitignore**: Generated keys in `firebase_service_account_keys/` must stay gitignored. Never commit JSON key files.
+- **IAM Propagation Delay**: After creating service account, IAM bindings may take 60s to propagate.
+- **Firebase CLI Version**: Older Firebase CLI versions don't support service account auth.
+- **Dynamic Project Discovery**: `data.google_projects` auto-discovers ALL Firebase-labeled projects in the org. Adding the `firebase:enabled` label to any GCP project causes it to get a service account with admin permissions on next apply. This is a security-sensitive behavior.
+- **No State Locking**: DynamoDB state lock is commented out. Never run concurrent `terraform apply` against the same environment — state corruption risk.
+- **State Contains Secrets**: Terraform state files contain base64-encoded service account private keys. Treat state buckets as highly sensitive. Restrict S3 access and enable server-side encryption.
+- **Provider Version Mismatch**: Root `versions.tf` pins AWS 4.64.0, modules pin 5.52.0. The module version takes precedence during apply, but the root constraint may cause confusion.
+- **Docker Image Trust**: The Makefile uses `devopsinfra/docker-terragrunt` (third-party image). Verify image integrity before use. Consider pinning by SHA digest.
+- **Additive IAM Only**: `google_project_iam_member` does not remove role bindings added outside Terraform. IAM drift is not detected or corrected.
+
+## GCP IAM Patterns (Reference)
+
+### Service Account Naming
+- CI/CD accounts: `bfan-firebase-ci-cd-{env}` (per environment)
+- FCM/SNS accounts: `bfan-firebase-fcm-sns-{env}` (per environment)
+- Account IDs are 6-30 chars, lowercase, hyphens allowed.
+
+### Key Management Best Practices
+1. **Prefer Workload Identity Federation** over service account keys where possible (GKE, Cloud Run, GitHub Actions OIDC). Keys are a last resort.
+2. **Monitor key age** via `gcloud iam service-accounts keys list` or GCP Asset Inventory.
+3. **Limit key count**: GCP allows max 10 keys per service account. With 1-day rotation and no cleanup, old keys may accumulate if Terraform state is lost.
+4. **Never download keys locally** unless for debugging. Use SSM for CI/CD access.
+5. **Audit key usage**: Enable GCP Audit Logs for `iam.serviceAccountKeys.create` to track who generates keys.
+
+### IAM Role Hierarchy (Firebase)
+- `roles/firebase.admin` > `roles/firebase.developAdmin` > `roles/firebase.viewer`
+- `roles/firebase.growthAdmin` covers: FCM, A/B Testing, Remote Config, Dynamic Links, In-App Messaging, Predictions
+- For FCM only: create a custom role with `cloudmessaging.messages.create`
+
+### Cross-Cloud Credential Flow
+```
+Developer runs `make apply-prod-eu`
+  → Authenticates to GCP via ADC (gcloud auth application-default login)
+  → Authenticates to AWS via SSO profile (aws sso login --profile prod-eu)
+  → Terragrunt discovers Firebase projects via GCP API
+  → Creates service accounts + keys in GCP
+  → Stores keys in AWS SSM Parameter Store
+  → CI/CD reads from SSM at build time
+```

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,382 @@
+# Security Audit: google_cloud_ci_cd_service_account_generator
+
+**Date:** 2026-02-17
+**Auditor:** DevOps Engineer (AI-assisted)
+**Scope:** IAM security, key rotation, least privilege, credential exposure, Terraform state, provider hygiene
+**Repo:** bfansports/google_cloud_ci_cd_service_account_generator
+
+---
+
+## Critical
+
+### C-1: `roles/firebase.admin` is overly permissive for CI/CD deployments
+
+**File:** `modules/google_cloud_ci_cd_service_account_generator/firebase_service_account.tf:13`
+
+```hcl
+role = "roles/firebase.admin"
+```
+
+`roles/firebase.admin` grants full read/write/delete access to every Firebase service (Firestore, RTDB, Storage, Hosting, Auth, Functions, etc.). CI/CD pipelines that only deploy Hosting or Functions do not need admin over Auth or Firestore data.
+
+**Risk:** A compromised service account key can delete production databases, exfiltrate user data, or modify auth providers.
+
+**Recommendation:** Replace with the minimum set of roles the CI/CD pipeline actually uses. Typical Firebase deployment needs:
+- `roles/firebase.developAdmin` (if deploying hosting/functions)
+- `roles/firebasehosting.admin` (hosting-only deployments)
+- `roles/cloudfunctions.developer` (Cloud Functions deployments)
+- `roles/firebaserules.admin` (security rules only)
+
+Audit which Firebase CLI commands run in CI/CD and grant only those roles. Use `roles/firebase.viewer` as a baseline and add write roles incrementally.
+
+---
+
+### C-2: Terraform state backend has no state locking (commented-out DynamoDB)
+
+**File:** All 6 `terragrunt.hcl` files (dev-eu, qa-eu, prod-eu x 2 modules)
+
+```hcl
+# dynamodb_table = "terraform-state-lock" # TODO: Create a DynamoDB table for state locking
+```
+
+Without state locking, concurrent `terraform apply` runs can corrupt the state file, leading to orphaned GCP service accounts, duplicate keys, or lost resource tracking. This is especially dangerous since every apply recreates ALL service account keys.
+
+**Risk:** Two engineers running `make apply-prod-eu` simultaneously can corrupt state and leave untracked service account keys in GCP that are never rotated or deleted.
+
+**Recommendation:** Create DynamoDB tables for state locking immediately:
+```bash
+for env in dev qa prod; do
+  aws dynamodb create-table \
+    --table-name terraform-state-lock \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --profile ${env}-eu
+done
+```
+Then uncomment the `dynamodb_table` line in all terragrunt.hcl files.
+
+---
+
+### C-3: Service account keys stored in Terraform state as plaintext
+
+**File:** `modules/google_cloud_ci_cd_service_account_generator/firebase_service_account_key.tf`
+
+The `google_service_account_key` resource stores the full private key in Terraform state (`private_key` attribute). The S3 backend has no server-side encryption configured.
+
+```hcl
+backend "s3" {
+  profile = "${local.aws_profile}"
+  bucket  = "${local.terraform_bucket_name}"
+  key     = "${local.module_name}.tfstate"
+  region  = "eu-west-1"
+}
+```
+
+No `encrypt = true`, no `kms_key_id`, no bucket policy enforcing encryption.
+
+**Risk:** Anyone with S3 read access to the state bucket can extract every service account private key for every Firebase project.
+
+**Recommendation:** Add encryption to the S3 backend:
+```hcl
+backend "s3" {
+  encrypt        = true
+  kms_key_id     = "alias/terraform-state"
+  # ... existing fields
+}
+```
+Also apply an S3 bucket policy denying `s3:GetObject` without `aws:SecureTransport`.
+
+---
+
+## High
+
+### H-1: Docker container runs as root with host credential mounts
+
+**File:** `Makefile:5-11`
+
+```makefile
+DOCKER_RUN = docker run -it --rm \
+    -e AWS_PROFILE=$(AWS_PROFILE) \
+    -v ~/.aws/config:/root/.aws/config \
+    -v ~/.aws/sso/cache/:/root/.aws/sso/cache/ \
+    -v ~/.config/gcloud/application_default_credentials.json:/root/.config/gcloud/application_default_credentials.json \
+    -v $(PWD):/app/ \
+    -w /app/$*
+```
+
+The container runs as `root` and mounts the host's AWS SSO cache and Google Cloud ADC credentials. A supply-chain attack on the `devopsinfra/docker-terragrunt` image could exfiltrate both AWS and GCP credentials.
+
+**Risk:** Compromise of the third-party Docker image gives the attacker AWS SSO tokens and GCP application default credentials.
+
+**Recommendations:**
+1. Pin the Docker image by SHA digest, not just by tag.
+2. Add `--read-only` flag and mount only specific credential files needed.
+3. Consider running Terragrunt natively (the `make dev` target installs it locally via `tenv`), eliminating the Docker attack surface entirely.
+4. Mount credentials as read-only: `-v ~/.aws/config:/root/.aws/config:ro`
+
+---
+
+### H-2: No key count limits -- every `apply` creates keys for ALL Firebase projects in the org
+
+**File:** `modules/google_cloud_ci_cd_service_account_generator/data.tf`
+
+```hcl
+data "google_projects" "firebase_projects" {
+  filter = "labels.firebase:enabled lifecycleState:ACTIVE"
+}
+```
+
+This dynamically discovers ALL projects with `firebase:enabled` label. If a new Firebase project is added anywhere in the GCP org, it automatically gets a service account with `roles/firebase.admin` and a key stored in SSM on the next apply.
+
+**Risk:** Unintended scope creep. New projects get admin service accounts without explicit opt-in. An attacker who can add the `firebase:enabled` label to any GCP project gets an admin service account key delivered to SSM.
+
+**Recommendation:** Use an explicit allowlist of project IDs instead of dynamic discovery:
+```hcl
+variable "firebase_project_ids" {
+  type        = list(string)
+  description = "Explicit list of Firebase project IDs to manage"
+}
+```
+Or add a more specific label like `labels.bfan-cicd:enabled` that is restricted by IAM policy.
+
+---
+
+### H-3: `roles/firebase.growthAdmin` may be overly broad for FCM/SNS integration
+
+**File:** `modules/firebase_cloud_messaging_aws_sns/firebase_service_account.tf:15`
+
+```hcl
+role = "roles/firebase.growthAdmin"
+```
+
+The commented-out alternatives show this was a workaround. `roles/firebase.growthAdmin` includes permissions for Firebase A/B Testing, Remote Config, Dynamic Links, In-App Messaging, and Predictions -- not just Cloud Messaging.
+
+**Risk:** Service accounts used by SNS for push notifications have write access to Remote Config and A/B Testing experiments.
+
+**Recommendation:** Create a custom IAM role with only the FCM permissions needed:
+```hcl
+resource "google_project_iam_custom_role" "fcm_sender" {
+  role_id     = "fcmSender"
+  title       = "FCM Message Sender"
+  permissions = [
+    "cloudmessaging.messages.create",
+    "firebase.projects.get"
+  ]
+}
+```
+
+---
+
+### H-4: Malformed IAM ARNs in SNS platform application
+
+**File:** `modules/firebase_cloud_messaging_aws_sns/aws_sns_platform_application.tf:18-19`
+
+```hcl
+failure_feedback_role_arn = "arn:aws:iam::${local.aws_account_id}:role/SNSFailureFeedback"
+success_feedback_role_arn = "arn:aws:iam::${local.aws_account_id}:role/SNSSuccessFeedback"
+```
+
+These ARNs have a double colon (`iam::`) which is the correct format for IAM (global service, no region). However, the roles `SNSFailureFeedback` and `SNSSuccessFeedback` are referenced but not created by this Terraform code. If they do not exist, SNS delivery failure logging is silently disabled.
+
+**Risk:** Push notification delivery failures go unmonitored. No alerting on FCM delivery issues.
+
+**Recommendation:** Either create the IAM roles in this Terraform config, or add a `data` source to validate they exist:
+```hcl
+data "aws_iam_role" "sns_failure_feedback" {
+  name = "SNSFailureFeedback"
+}
+```
+
+---
+
+## Medium
+
+### M-1: Key rotation period is 1 day but depends on manual `terraform apply`
+
+**File:** `modules/google_cloud_ci_cd_service_account_generator/firebase_service_account_key.tf:3`
+
+```hcl
+rotation_days = 1 # note this requires the terraform to be run regularly
+```
+
+The `time_rotating` resource only marks keys as needing rotation after 1 day. But rotation only happens when someone runs `terraform apply`. If nobody runs it for weeks, keys persist far beyond 1 day.
+
+**Risk:** False sense of rotation security. Keys may live for weeks or months without actual rotation.
+
+**Recommendation:**
+1. Set up a scheduled CI/CD pipeline (GitHub Actions cron) to run `make apply-*` daily.
+2. Or increase `rotation_days` to a realistic value (e.g., 90 days) and add monitoring for key age.
+3. Add a CloudWatch alarm or GCP monitoring alert when keys exceed the rotation threshold.
+
+---
+
+### M-2: Stale provider versions with known vulnerabilities
+
+**File:** `versions.tf` (root) and `modules/*/versions.tf`
+
+Root `versions.tf`:
+```hcl
+aws = { version = "4.64.0" }  # Released April 2023, ~3 years old
+```
+
+Module `versions.tf`:
+```hcl
+google = { version = "5.32.0" }  # Released June 2024
+aws    = { version = "5.52.0" }  # Released June 2024
+time   = { version = "0.11.2" }  # Released May 2024
+```
+
+The root `versions.tf` pins AWS provider to 4.64.0 while modules use 5.52.0. This version mismatch could cause conflicts. Additionally, all versions are 1.5+ years old.
+
+**Risk:** Missing security patches, bug fixes, and deprecated API compatibility.
+
+**Recommendation:** Update all providers to current versions. Align root and module version constraints. Use `~>` constraint for minor version flexibility:
+```hcl
+aws = { version = "~> 5.80" }
+google = { version = "~> 6.15" }
+```
+
+---
+
+### M-3: SSM parameters created without explicit KMS encryption key
+
+**File:** `modules/google_cloud_ci_cd_service_account_generator/aws_ssm_parameter_account_key.tf`
+
+```hcl
+resource "aws_ssm_parameter" "firebase_service_account_key" {
+  type  = "SecureString"
+  value = base64decode(...private_key)
+}
+```
+
+`SecureString` uses the default `aws/ssm` KMS key. This key cannot have restricted access policies -- anyone with SSM read permissions can decrypt.
+
+**Risk:** Broad SSM read access in the AWS account means broad access to all service account keys.
+
+**Recommendation:** Use a customer-managed KMS key with a restrictive key policy:
+```hcl
+resource "aws_ssm_parameter" "firebase_service_account_key" {
+  type   = "SecureString"
+  key_id = aws_kms_key.firebase_credentials.arn
+  value  = base64decode(...)
+}
+```
+
+---
+
+### M-4: No `google_project_iam_binding` audit -- using additive `iam_member` without checking existing bindings
+
+**File:** `modules/*/firebase_service_account.tf`
+
+`google_project_iam_member` is additive -- it does not manage the complete role membership. Other service accounts or users with the same role will not be visible or managed by Terraform.
+
+**Risk:** Cannot detect if additional principals have been manually granted `roles/firebase.admin` outside of Terraform. No drift detection for IAM.
+
+**Recommendation:** Consider using `google_project_iam_binding` (authoritative for a role) for the specific service account roles, or implement IAM audit logging and alerts for out-of-band changes.
+
+---
+
+### M-5: Terragrunt config duplication across all 6 environment directories
+
+**Files:** All `*/*/terragrunt.hcl` files are identical.
+
+The identical terragrunt.hcl is copy-pasted 6 times. Any security fix (e.g., enabling state encryption) must be applied to all 6 files manually.
+
+**Risk:** Configuration drift between environments. A security fix applied to prod but missed in dev.
+
+**Recommendation:** Use a root `terragrunt.hcl` with `include` blocks:
+```hcl
+# root terragrunt.hcl
+remote_state { ... }
+retry_max_attempts = 5
+```
+Then each environment file only specifies its overrides.
+
+---
+
+## Low
+
+### L-1: OpenTofu 1.9.0 and Terragrunt 0.72.0 may have known issues
+
+**Files:** `.opentofu-version`, `.terragrunt-version`
+
+No specific CVEs identified, but pinned versions should be reviewed quarterly.
+
+**Recommendation:** Add a Dependabot or Renovate config to track OpenTofu and Terragrunt releases.
+
+---
+
+### L-2: `firebase_service_account_keys/` directory has `.gitkeep` but no README
+
+The directory exists for local testing but has no documentation on proper handling of downloaded keys.
+
+**Recommendation:** Add a `README.md` in the directory:
+```
+Keys downloaded here are for local testing only.
+NEVER commit .json files. They are gitignored.
+Delete keys after use: rm -f *.json
+```
+
+---
+
+### L-3: No `.terraform-docs.yml` or automated documentation
+
+Module inputs, outputs, and provider requirements are not auto-documented.
+
+**Recommendation:** Add `terraform-docs` generation to CI.
+
+---
+
+### L-4: Makefile exposes GCP token in curl validation
+
+**File:** `Makefile:43-51`
+
+```makefile
+@token=$$(gcloud auth application-default print-access-token); \
+if curl -s -H "Authorization: Bearer $$token" https://www.googleapis.com/oauth2/v1/userinfo ...
+```
+
+The access token appears in process listings (`ps aux`). Low risk since it is short-lived (1 hour) and only used locally.
+
+**Recommendation:** Minor. Consider using `gcloud auth application-default print-access-token --format=json | jq -r .email` to avoid raw token exposure, or use `gcloud auth list` to check the active account.
+
+---
+
+## Agent Skill Improvements
+
+### S-1: CLAUDE.md should document GCP IAM patterns and security gotchas
+
+The existing CLAUDE.md covers operations well but lacks:
+- IAM role explanations for the roles actually used
+- Key management lifecycle documentation
+- Security review checklist for changes
+- Cross-cloud credential flow diagram
+
+**Action:** Updated in this PR.
+
+### S-2: CLAUDE.md should warn about the dynamic project discovery risk
+
+The `data.google_projects` filter auto-discovers projects. Any CLAUDE.md consumer (human or AI) should understand this implicit behavior.
+
+**Action:** Added to Gotchas section in this PR.
+
+---
+
+## Positive Observations
+
+1. **Key rotation intent is correct.** Using `time_rotating` + `keepers` is the right Terraform pattern for key rotation. The implementation just needs a scheduled executor.
+
+2. **SSM SecureString usage.** Keys are stored as `SecureString` in SSM, not plaintext `String`. This provides baseline encryption.
+
+3. **Service account per-project isolation.** Each Firebase project gets its own service account, limiting blast radius if one key is compromised. This is better than a single org-wide service account.
+
+4. **Gitignore for credential files.** `.gitignore` correctly excludes `firebase_service_account_keys/*.json` and `.terraform` state.
+
+5. **Environment separation.** Dev/QA/Prod are cleanly separated with distinct AWS profiles and state buckets.
+
+6. **Retry logic for known provider bug.** The `retryable_errors` config handles the known Google provider race condition gracefully.
+
+7. **Version pinning.** All providers, OpenTofu, and Terragrunt versions are pinned, preventing supply-chain drift.
+
+8. **Google Cloud auth validation.** The Makefile validates the correct account (`dev-google@bfansports.com`) before running, preventing accidental operations with the wrong identity.


### PR DESCRIPTION
## Summary\n\nTwo-pass DevOps security audit of the Google Cloud CI/CD Service Account Generator, focused on IAM security, key rotation, least privilege, and credential exposure.\n\n### Files Changed\n- **FINDINGS.md** — Full audit report (3 Critical, 4 High, 5 Medium, 4 Low findings)\n- **CLAUDE.md** — Enhanced with GCP IAM patterns, service account roles, key management lifecycle, security architecture diagram, and expanded gotchas\n\n### Key Findings\n\n**Critical:**\n- C-1: `roles/firebase.admin` overly permissive for CI/CD (should use scoped roles)\n- C-2: No Terraform state locking (DynamoDB table commented out in all 6 terragrunt.hcl)\n- C-3: Service account keys in Terraform state with no S3 encryption configured\n\n**High:**\n- H-1: Docker container runs as root with host credential mounts\n- H-2: Dynamic project discovery creates admin SAs for ALL Firebase-labeled projects\n- H-3: `roles/firebase.growthAdmin` overly broad for FCM/SNS use case\n- H-4: SNS feedback IAM roles referenced but not created by Terraform\n\n**Medium:**\n- M-1: Key rotation depends on manual apply (no scheduled automation)\n- M-2: Provider versions 1.5+ years stale; root/module version mismatch\n- M-3: SSM uses default KMS key instead of customer-managed\n- M-4: Additive IAM bindings do not detect drift\n- M-5: Terragrunt config duplicated 6 times (drift risk)\n\n### Positive Observations\n- Correct key rotation pattern (time_rotating + keepers)\n- Per-project service account isolation\n- SSM SecureString usage\n- Clean environment separation\n- Credential files properly gitignored\n\n## Test plan\n- [ ] Review each finding for accuracy against live infrastructure\n- [ ] Prioritize C-1 (reduce IAM roles) and C-2 (enable state locking) for immediate action\n- [ ] Verify provider version upgrade path does not break existing state\n- [ ] Validate CLAUDE.md accuracy with team members familiar with the project\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"